### PR TITLE
Update base image to latest release hashicorp/terraform:1.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:1.4.5
+FROM hashicorp/terraform:1.7.4
 
 LABEL \
     repository="https://github.com/sheeeng/terraform-pull-request-commenter" \


### PR DESCRIPTION
The existing base image 1.4.5 (released 4/12/23) results in the Action failing with the following error:
"Error relocating /usr/bin/curl: curl_global_trace: symbol not found"